### PR TITLE
Remove parentheses from publication venue formatting

### DIFF
--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -254,7 +254,7 @@ const HomePage = ({ darkMode, onToggleDarkMode }) => {
                   Problem-Solving in Language Model Networks
                 </Link>
               } 
-              secondary="ALIFE (2024)" 
+              secondary="ALIFE 2024"
             />
           </ListItem>
           <ListItem>
@@ -276,7 +276,7 @@ const HomePage = ({ darkMode, onToggleDarkMode }) => {
                   LLM-POET: Evolving Complex Environments using Large Language Models
                 </Link>
               } 
-              secondary="GECCO (2024)" 
+              secondary="GECCO 2024"
             />
           </ListItem>
           <ListItem>
@@ -298,7 +298,7 @@ const HomePage = ({ darkMode, onToggleDarkMode }) => {
                   Simulating Emergence of Novelties using Agent-Based Models
                 </Link>
               } 
-              secondary="PLOS ONE (2023)" 
+              secondary="PLOS ONE 2023"
             />
           </ListItem>
         </List>


### PR DESCRIPTION
## Summary
Updated the formatting of publication venues in the HomePage component to remove parentheses around conference/journal names and years for consistency and improved readability.

## Changes
- Removed parentheses from publication venue labels in the publications list
- Updated formatting from `VENUE (YEAR)` to `VENUE YEAR` format across three publication entries:
  - "ALIFE (2024)" → "ALIFE 2024"
  - "GECCO (2024)" → "GECCO 2024"
  - "PLOS ONE (2023)" → "PLOS ONE 2023"

## Details
These changes apply to the secondary text fields of ListItem components displaying publication metadata. The new format provides a cleaner, more modern appearance while maintaining all necessary information about the publication venue and year.

https://claude.ai/code/session_016viAwcUvgVaoRc2smiNnF6