### PR TITLE
Add new ICLR 2026 publication to homepage

### DIFF
--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -208,9 +208,15 @@ const HomePage = ({ darkMode, onToggleDarkMode }) => {
         <Typography variant="h6">Publications</Typography>
         <List dense>
           <ListItem>
-            <ListItemText 
+            <ListItemText
+              primary="Discovering Novel LLM Experts via Task-Capability Coevolution"
+              secondary="ICLR 2026"
+            />
+          </ListItem>
+          <ListItem>
+            <ListItemText
               primary={
-                <Link 
+                <Link
                   href="https://neurips.cc/virtual/2025/poster/115192"
                   target="_blank"
                   rel="noopener noreferrer"
@@ -226,7 +232,7 @@ const HomePage = ({ darkMode, onToggleDarkMode }) => {
                   Continuous Thought Machines
                 </Link>
               }
-              secondary="NeurIPS 2025 (Spotlight)" 
+              secondary="NeurIPS 2025 (Spotlight)"
             />
           </ListItem>
           <ListItem>

--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -209,7 +209,23 @@ const HomePage = ({ darkMode, onToggleDarkMode }) => {
         <List dense>
           <ListItem>
             <ListItemText
-              primary="Discovering Novel LLM Experts via Task-Capability Coevolution"
+              primary={
+                <Link
+                  href="https://arxiv.org/abs/2604.14969"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  sx={{
+                    color: 'inherit',
+                    textDecoration: 'none',
+                    '&:hover': {
+                      textDecoration: 'underline',
+                      textDecorationColor: theme.palette.text.primary,
+                    },
+                  }}
+                >
+                  Discovering Novel LLM Experts via Task-Capability Coevolution
+                </Link>
+              }
               secondary="ICLR 2026"
             />
           </ListItem>


### PR DESCRIPTION
## Summary
Added a new publication entry to the Publications section on the HomePage, featuring a paper accepted to ICLR 2026.

## Key Changes
- Added new publication: "Discovering Novel LLM Experts via Task-Capability Coevolution" (ICLR 2026)
- Linked to the arXiv preprint (https://arxiv.org/abs/2604.14969)
- Implemented consistent styling with existing publication links, including hover effects
- Applied minor formatting cleanup (trailing whitespace removal) to adjacent publication entries

## Implementation Details
- The new publication entry follows the same structure as existing entries with a `ListItem` containing a `ListItemText` component
- The link includes proper accessibility attributes (`target="_blank"`, `rel="noopener noreferrer"`)
- Hover styling matches the existing publication link behavior with underline decoration
- Positioned as the first publication in the list (most recent)

https://claude.ai/code/session_012Wcu7efRe3CxdQM5RcH8oy